### PR TITLE
Added boxplot rcparams to dark_background.mplstyle

### DIFF
--- a/lib/matplotlib/mpl-data/stylelib/dark_background.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/dark_background.mplstyle
@@ -21,3 +21,47 @@ figure.edgecolor: black
 savefig.facecolor: black
 savefig.edgecolor: black
 
+#### Boxplot
+#boxplot.notch       : False
+#boxplot.vertical    : True
+#boxplot.whiskers    : 1.5
+#boxplot.bootstrap   : None
+#boxplot.patchartist : False
+#boxplot.showmeans   : False
+#boxplot.showcaps    : True
+#boxplot.showbox     : True
+#boxplot.showfliers  : True
+#boxplot.meanline    : False
+
+#boxplot.flierprops.color           : black
+#boxplot.flierprops.marker          : o
+#boxplot.flierprops.markerfacecolor : none
+#boxplot.flierprops.markeredgecolor : black
+#boxplot.flierprops.markeredgewidth : 1.0
+#boxplot.flierprops.markersize      : 6
+#boxplot.flierprops.linestyle       : none
+#boxplot.flierprops.linewidth       : 1.0
+
+#boxplot.boxprops.color     : black
+#boxplot.boxprops.linewidth : 1.0
+#boxplot.boxprops.linestyle : -
+
+#boxplot.whiskerprops.color     : black
+#boxplot.whiskerprops.linewidth : 1.0
+#boxplot.whiskerprops.linestyle : -
+
+#boxplot.capprops.color     : black
+#boxplot.capprops.linewidth : 1.0
+#boxplot.capprops.linestyle : -
+
+#boxplot.medianprops.color     : C1
+#boxplot.medianprops.linewidth : 1.0
+#boxplot.medianprops.linestyle : -
+
+#boxplot.meanprops.color           : C2
+#boxplot.meanprops.marker          : ^
+#boxplot.meanprops.markerfacecolor : C2
+#boxplot.meanprops.markeredgecolor : C2
+#boxplot.meanprops.markersize      :  6
+#boxplot.meanprops.linestyle       : --
+#boxplot.meanprops.linewidth       : 1.0


### PR DESCRIPTION
I have added boxplot rcparams to dark_background.mplstyle as suggested by @tacaswell to make boxes visible in dark_background style which will solve issue #15675 .

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
